### PR TITLE
make it rain again

### DIFF
--- a/static/js/rain.js
+++ b/static/js/rain.js
@@ -3,7 +3,7 @@ let rainSketch = function (p) {
     p.font;
 
     p.preload = function () {
-        p.font = p.loadFont('https://joschahenningsen.github.io/static/font/RobotoMonoforPowerline.ttf');
+        p.font = p.loadFont('/static/font/RobotoMonoforPowerline.ttf');
     }
 
     p.setup = function () {


### PR DESCRIPTION
CORS prevents loading the font from https://joschahenningsen.github.io/ when the page is served from https://joschas.page/. Using a relative URL fixes that.